### PR TITLE
Fix NLPModelsKnitro for future version of Knitro.jl

### DIFF
--- a/src/NLPModelsKnitro.jl
+++ b/src/NLPModelsKnitro.jl
@@ -120,7 +120,7 @@ function _knitro(::Val{true}, nlp :: AbstractNLPModel;
   end
 
   # register callbacks
-  cb = KNITRO.KN_add_eval_callback(kc, evalAll)
+  cb = KNITRO.KN_add_eval_callback_all(kc, evalAll)
   KNITRO.KN_set_cb_grad(kc, cb, evalAll,
                         jacIndexCons=convert(Vector{Int32}, jrows .- 1),  # indices must be 0-based
                         jacIndexVars=convert(Vector{Int32}, jcols .- 1))


### PR DESCRIPTION
A [recent PR](https://github.com/JuliaOpt/KNITRO.jl/pull/109) on KNITRO.jl has introduced a breaking change: the function to set all evaluation callbacks all in once has been renamed to `KN_add_eval_callback_all`: 
https://github.com/JuliaOpt/KNITRO.jl/blob/master/src/kn_callbacks.jl#L429

We aimed at expliciting the names of the functions used inside Knitro.jl, and we found the name `KN_add_eval_callback` unclear, as it was also used by the function that sets a partial callback on the objective and/or the constraints:
https://github.com/JuliaOpt/KNITRO.jl/blob/master/src/kn_callbacks.jl#L479

We plan to release Knitro.jl v0.7 by the end of the week, hence the reason of this PR. 