### PR TITLE
Update newpoint callback to Knitro.jl 0.9

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ end
 
 function test_with_callback()
   function callback(kc, x, lambda_, userParams)
-    if KNITRO.KN_get_number_iters(userParams) > 1
+    if KNITRO.KN_get_number_iters(kc) > 1
       return KNITRO.KN_RC_USER_TERMINATION
     end
     return 0


### PR DESCRIPTION
This small PR fixes NLPModelsKnitro.jl with Knitro.jl 0.9. 
Knitro.jl 0.9 introduces a breaking change in the way it handles user params in callbacks. 
- In Knitro you could define userparams for different callbacks (evaluation callbacks, new points callbacks, mip callbacks, ...)
- Before Knitro 0.9.jl, we could only add user params to evaluation callbacks. 
- With Knitro.jl 0.9, you could define user params for all kind of callbacks, as you would do in C. 
- From now on, the expected signature of callbacks in Julia changes a bit. `userParams` now stores a proper user params, and not anymore a `KNITRO.Model`. But we add new functions to query informations (number of iterations, number of variables,...) directly from the pointer `kc`.
- We acknowledge that this breaking change is annoying. But we believe that it improves the current Julia wrapper of Knitro, and allows more flexibility.