### PR TITLE
additional return statuses

### DIFF
--- a/src/NLPModelsKnitro.jl
+++ b/src/NLPModelsKnitro.jl
@@ -37,6 +37,9 @@ function knitro_statuses(code::Integer)
   if code == -100
     return :acceptable
   end
+  if -103 ≤ code ≤ -101
+    return :stalled #feasible
+  end
   if -299 ≤ code ≤ -200
     return :infeasible
   end
@@ -52,7 +55,7 @@ function knitro_statuses(code::Integer)
   if code == -402 || code == -412  # -402 = feasible, -412 = infeasible
     return :max_eval
   end
-  if -599 ≤ code ≤ -500
+  if -600 ≤ code ≤ -500
     return :exception
   end
   return :unknown


### PR DESCRIPTION
Update the function `knitro_statuses` to return additional statuses, see [return codes documentation](https://www.artelys.com/docs/knitro/3_referenceManual/returnCodes.html). In particular, the following were not handled:
- **-101** *Primal feasible solution; the optimization terminated because the relative change in the solution estimate is less than that specified by the parameter*.
- **-102** *Primal feasible solution estimate cannot be improved; desired accuracy in dual feasibility could not be achieved. No further progress can be made.*
- **-103** *Primal feasible solution; the optimization terminated because the relative change in the objective function is less than that specified by the parameter*.
- **-600** internal error.

Should we also add `infeasible` and `max_iter` statuses for integer problems?