### PR TITLE
add nlpmodelsmodifiers and adnlpmodels

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,13 @@ version = "0.5.0"
 [deps]
 KNITRO = "67920dd8-b58e-52a8-8622-53c4cffbe346"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
+NLPModelsModifiers = "e01155f1-5c6f-4375-a9d8-616dd036575f"
 SolverTools = "b5612192-2639-5dc1-abfe-fbedd65fab29"
 
 [compat]
 KNITRO = "0.9"
 NLPModels = "0.14"
+NLPModelsModifiers = "0.1"
 SolverTools = "0.4"
 julia = "1.3.0"
 

--- a/src/NLPModelsKnitro.jl
+++ b/src/NLPModelsKnitro.jl
@@ -2,7 +2,7 @@ module NLPModelsKnitro
 
 export knitro
 
-using NLPModels, KNITRO, SolverTools
+using NLPModels, NLPModelsModifiers, KNITRO, SolverTools
 
 const KNITRO_VERSION = KNITRO.unsafe_get_release()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 
 using KNITRO
 
-using NLPModels, NLPModelsKnitro
+using ADNLPModels, NLPModelsKnitro
 
 function test_unconstrained()
   nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])


### PR DESCRIPTION
I tested @abelsiqueira update PR #40 , and added the missing `NLPModelsModifiers` (since `NLPModelsKnitro.jl` uses `FeasibilityFormNLS`). 