### PR TITLE
bump to SolverCore 0.1 [Merge only after 0.5.0 release]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,13 +7,13 @@ version = "0.5.0"
 KNITRO = "67920dd8-b58e-52a8-8622-53c4cffbe346"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 NLPModelsModifiers = "e01155f1-5c6f-4375-a9d8-616dd036575f"
-SolverTools = "b5612192-2639-5dc1-abfe-fbedd65fab29"
+SolverCore = "ff4d7338-4cf1-434d-91df-b86cb86fb843"
 
 [compat]
 KNITRO = "0.9, 0.10"
 NLPModels = "0.14"
 NLPModelsModifiers = "0.1"
-SolverTools = "0.4"
+SolverCore = "0.1"
 julia = "1.3.0"
 
 [extras]

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,6 +1,6 @@
 export knitro
 
-using NLPModels, NLPModelsModifiers, SolverTools
+using NLPModels, NLPModelsModifiers, SolverCore
 
 # Knitro does not accept least-squares problems with constraints other than bounds.
 # We must treat those as general NLPs.


### PR DESCRIPTION
SolverTools 0.5.0 is no longer necessary and replaced by SolverCore.
This will close #43 .