### PR TITLE
Add solver structure and tests

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -1,4 +1,4 @@
-export knitro
+export knitro, knitro!, KnitroSolver, finalize, setparams!
 
 using NLPModels, NLPModelsModifiers, SolverCore
 
@@ -59,5 +59,96 @@ function knitro_statuses(code::Integer)
   return :unknown
 end
 
+mutable struct KnitroSolver
+  kc
+end
+
+function Base.finalize(solver::KnitroSolver)
+#  KNITRO.KN_reset_params_to_defaults(solver.kc)
+  KNITRO.KN_free(solver.kc)
+end
+
+# pass options to KNITRO
+# could remove some stuff from both functions below (careful to default x0)
+function setparams!(solver::KnitroSolver; kwargs...)
+  kc = solver.kc
+  KNITRO.KN_reset_params_to_defaults(kc)
+  # set primal and dual initial guess
+  kwargs = Dict(kwargs)
+  if :x0 ∈ keys(kwargs)
+    KNITRO.KN_set_var_primal_init_values(kc, kwargs[:x0])
+    pop!(kwargs, :x0)
+  end
+  if :y0 ∈ keys(kwargs)
+    KNITRO.KN_set_con_dual_init_values(kc, kwargs[:y0])
+    pop!(kwargs, :y0)
+  end
+  if :z0 ∈ keys(kwargs)
+    KNITRO.KN_set_var_dual_init_values(kc, kwargs[:z0])
+    pop!(kwargs, :z0)
+  end
+
+  # specify that we are able to provide the Hessian without including the objective
+  KNITRO.KN_set_param(kc, KNITRO.KN_PARAM_HESSIAN_NO_F, KNITRO.KN_HESSIAN_NO_F_ALLOW)
+
+  # pass options to KNITRO
+  for (k, v) in kwargs
+    KNITRO.KN_set_param(kc, string(k), v)
+  end
+
+  return solver
+end
+
+KnitroSolver(nlp::AbstractNLPModel; kwargs...) = KnitroSolver(_is_general_nlp(nlp), nlp; kwargs...)
+
 include("nlp.jl")
 include("nls.jl")
+
+knitro!(nlp::AbstractNLPModel, solver::KnitroSolver) = _knitro!(nlp, solver)
+
+function _knitro(
+  val,
+  nlp::AbstractNLPModel;
+  callback::Union{Function, Nothing} = nothing,
+  kwargs...,
+)
+  solver = KnitroSolver(val, nlp, callback=callback; kwargs...)
+  stats = _knitro!(nlp, solver)
+  finalize(solver)
+  return stats
+end
+
+function _knitro!(nlp::AbstractNLPModel, solver::KnitroSolver)
+  kc = solver.kc
+  t = @timed begin
+    nStatus = KNITRO.KN_solve(kc)
+  end
+
+  nStatus, obj_val, x, lambda_ = KNITRO.KN_get_solution(kc)
+  n = length(x) 
+  m = length(lambda_) - n
+  primal_feas = KNITRO.KN_get_abs_feas_error(kc)
+  dual_feas = KNITRO.KN_get_abs_opt_error(kc)
+  iter = KNITRO.KN_get_number_iters(kc)
+  if KNITRO_VERSION ≥ v"12.0"
+    Δt = KNITRO.KN_get_solve_time_cpu(kc)
+    real_time = KNITRO.KN_get_solve_time_real(kc)
+  else
+    Δt = real_time = t[2]
+  end
+
+  return GenericExecutionStats(
+    knitro_statuses(nStatus),
+    nlp,
+    solution = x,
+    objective = obj_val,
+    dual_feas = dual_feas,
+    iter = convert(Int, iter),
+    primal_feas = primal_feas,
+    elapsed_time = Δt,
+    multipliers = lambda_[1:m],
+    multipliers_L = lambda_[(m + 1):(m + n)],  # don't know how to get those separately
+    multipliers_U = eltype(x)[],
+    solver_specific = Dict(:internal_msg => nStatus, :real_time => real_time),
+  )
+end

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -3,9 +3,9 @@ function KnitroSolver(
   nlp::AbstractNLPModel;
   callback::Union{Function, Nothing} = nothing,
   kwargs...,
-) where T
+) where {T}
   n, m = nlp.meta.nvar, nlp.meta.ncon
-  
+
   kc = KNITRO.KN_new()
   KNITRO.KN_reset_params_to_defaults(kc)
   if nlp.meta.minimize
@@ -13,10 +13,10 @@ function KnitroSolver(
   else
     KNITRO.KN_set_obj_goal(kc, KNITRO.KN_OBJGOAL_MAXIMIZE)
   end
-  
+
   # add variables and bound constraints
   KNITRO.KN_add_vars(kc, n)
-  
+
   lvarinf = isinf.(nlp.meta.lvar)
   if !all(lvarinf)
     lvar = nlp.meta.lvar
@@ -26,7 +26,7 @@ function KnitroSolver(
     end
     KNITRO.KN_set_var_lobnds(kc, lvar)
   end
-  
+
   uvarinf = isinf.(nlp.meta.uvar)
   if !all(uvarinf)
     uvar = nlp.meta.uvar
@@ -158,6 +158,6 @@ function KnitroSolver(
 
   # set user-defined callback called after each iteration
   callback == nothing || KNITRO.KN_set_newpt_callback(kc, callback)
-  
+
   return KnitroSolver(kc)
 end

--- a/src/nls.jl
+++ b/src/nls.jl
@@ -1,18 +1,18 @@
-function _knitro(
+function KnitroSolver(
   ::Val{false},
   nls::AbstractNLSModel;
   callback::Union{Function, Nothing} = nothing,
   kwargs...,
-)
+) where T
   n, m, ne = nls.meta.nvar, nls.meta.ncon, nls.nls_meta.nequ
 
   if m > 0
     @warn "Knitro only treats bound-constrained least-squares problems; converting to feasibility form"
-    return knitro(FeasibilityFormNLS(nls), callback = callback; kwargs...)
+    fnls = FeasibilityFormNLS(nls)
+    return KnitroSolver(_is_general_nlp(fnls), fnls, callback = callback; kwargs...)
   end
 
   kc = KNITRO.KN_new()
-  release = KNITRO.get_release()
   KNITRO.KN_reset_params_to_defaults(kc)
   if nls.meta.minimize
     KNITRO.KN_set_obj_goal(kc, KNITRO.KN_OBJGOAL_MINIMIZE)
@@ -100,36 +100,5 @@ function _knitro(
   # set user-defined callback called after each iteration
   callback == nothing || KNITRO.KN_set_newpt_callback(kc, callback)
 
-  t = @timed begin
-    nStatus = KNITRO.KN_solve(kc)
-  end
-
-  nStatus, obj_val, x, lambda_ = KNITRO.KN_get_solution(kc)
-  primal_feas = KNITRO.KN_get_abs_feas_error(kc)
-  dual_feas = KNITRO.KN_get_abs_opt_error(kc)
-  iter = KNITRO.KN_get_number_iters(kc)
-  if KNITRO_VERSION ≥ v"12.0"
-    Δt = KNITRO.KN_get_solve_time_cpu(kc)
-    real_time = KNITRO.KN_get_solve_time_real(kc)
-  else
-    Δt = real_time = t[2]
-  end
-
-  KNITRO.KN_reset_params_to_defaults(kc)
-  KNITRO.KN_free(kc)
-
-  return GenericExecutionStats(
-    knitro_statuses(nStatus),
-    nls,
-    solution = x,
-    objective = obj_val,
-    dual_feas = dual_feas,
-    iter = convert(Int, iter),
-    primal_feas = primal_feas,
-    elapsed_time = Δt,
-    multipliers = lambda_[1:m],
-    multipliers_L = lambda_[(m + 1):(m + n)],  # don't know how to get those separately
-    multipliers_U = eltype(x)[],
-    solver_specific = Dict(:internal_msg => nStatus, :real_time => real_time),
-  )
+  return KnitroSolver(kc)
 end

--- a/src/nls.jl
+++ b/src/nls.jl
@@ -3,7 +3,7 @@ function KnitroSolver(
   nls::AbstractNLSModel;
   callback::Union{Function, Nothing} = nothing,
   kwargs...,
-) where T
+) where {T}
   n, m, ne = nls.meta.nvar, nls.meta.ncon, nls.nls_meta.nequ
 
   if m > 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,7 @@ function test_qp_with_solver_and_evals()
   Jx = KNITRO.KN_get_jacobian_values(solver.kc)
   @test Jx[1] == [0; 0]
   @test Jx[2] == [0; 1]
-  @test Jx[3] == [1; 1] 
+  @test Jx[3] == [1; 1]
   finalize(solver)
 end
 


### PR DESCRIPTION
Make a `KnitroSolver` structure, which allows evaluating the model after a solve call.
This solves #55 .

The issue of solving the model again with a different solution remains as
```
ERROR: Both residuals and an objective function have been added to the model.
       The current version of Knitro does not support this.
```

Tested locally.