### PR TITLE
update to new Knitro.jl's interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ NLPModelsModifiers = "e01155f1-5c6f-4375-a9d8-616dd036575f"
 SolverCore = "ff4d7338-4cf1-434d-91df-b86cb86fb843"
 
 [compat]
-KNITRO = "0.9, 0.10, 0.11, 0.12"
+KNITRO = "0.13"
 NLPModels = "0.14, 0.15, 0.16, 0.17, 0.18"
 NLPModelsModifiers = "0.1, 0.2, 0.3, 0.4, 0.5"
 SolverCore = "0.1, 0.2"

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -24,7 +24,7 @@ function KnitroSolver(
       lvar = copy(nlp.meta.lvar)
       lvar[lvarinf] .= -KNITRO.KN_INFINITY
     end
-    KNITRO.KN_set_var_lobnds(kc, lvar)
+    KNITRO.KN_set_var_lobnds_all(kc, lvar)
   end
 
   uvarinf = isinf.(nlp.meta.uvar)
@@ -34,7 +34,7 @@ function KnitroSolver(
       uvar = copy(nlp.meta.uvar)
       uvar[uvarinf] .= KNITRO.KN_INFINITY
     end
-    KNITRO.KN_set_var_upbnds(kc, uvar)
+    KNITRO.KN_set_var_upbnds_all(kc, uvar)
   end
 
   # add constraints
@@ -51,23 +51,23 @@ function KnitroSolver(
     ucon = copy(nlp.meta.ucon)
     ucon[uconinf] .= KNITRO.KN_INFINITY
   end
-  KNITRO.KN_set_con_lobnds(kc, lcon)
-  KNITRO.KN_set_con_upbnds(kc, ucon)
+  KNITRO.KN_set_con_lobnds_all(kc, lcon)
+  KNITRO.KN_set_con_upbnds_all(kc, ucon)
 
   # set primal and dual initial guess
   kwargs = Dict(kwargs)
   if :x0 ∈ keys(kwargs)
-    KNITRO.KN_set_var_primal_init_values(kc, kwargs[:x0])
+    KNITRO.KN_set_var_primal_init_values_all(kc, kwargs[:x0])
     pop!(kwargs, :x0)
   else
-    KNITRO.KN_set_var_primal_init_values(kc, nlp.meta.x0)
+    KNITRO.KN_set_var_primal_init_values_all(kc, nlp.meta.x0)
   end
   if :y0 ∈ keys(kwargs)
-    KNITRO.KN_set_con_dual_init_values(kc, kwargs[:y0])
+    KNITRO.KN_set_con_dual_init_values_all(kc, kwargs[:y0])
     pop!(kwargs, :y0)
   end
   if :z0 ∈ keys(kwargs)
-    KNITRO.KN_set_var_dual_init_values(kc, kwargs[:z0])
+    KNITRO.KN_set_var_dual_init_values_all(kc, kwargs[:z0])
     pop!(kwargs, :z0)
   end
 

--- a/src/nls.jl
+++ b/src/nls.jl
@@ -30,7 +30,7 @@ function KnitroSolver(
       lvar = copy(nls.meta.lvar)
       lvar[lvarinf] .= -KNITRO.KN_INFINITY
     end
-    KNITRO.KN_set_var_lobnds(kc, lvar)
+    KNITRO.KN_set_var_lobnds_all(kc, lvar)
   end
 
   uvarinf = isinf.(nls.meta.uvar)
@@ -40,19 +40,19 @@ function KnitroSolver(
       uvar = copy(nls.meta.uvar)
       uvar[uvarinf] .= KNITRO.KN_INFINITY
     end
-    KNITRO.KN_set_var_upbnds(kc, uvar)
+    KNITRO.KN_set_var_upbnds_all(kc, uvar)
   end
 
   # set primal and dual initial guess
   kwargs = Dict(kwargs)
   if :x0 ∈ keys(kwargs)
-    KNITRO.KN_set_var_primal_init_values(kc, kwargs[:x0])
+    KNITRO.KN_set_var_primal_init_values_all(kc, kwargs[:x0])
     pop!(kwargs, :x0)
   else
-    KNITRO.KN_set_var_primal_init_values(kc, nls.meta.x0)
+    KNITRO.KN_set_var_primal_init_values_all(kc, nls.meta.x0)
   end
   if :z0 ∈ keys(kwargs)
-    KNITRO.KN_set_var_dual_init_values(kc, kwargs[:z0])
+    KNITRO.KN_set_var_dual_init_values_all(kc, kwargs[:z0])
     pop!(kwargs, :z0)
   end
 


### PR DESCRIPTION
KNITRO.jl has been updated to generate the C wrapper automatically with Clang.jl. By doing so, we support all the functions provided in Knitro's C API. However, that comes with a few breaking changes. This PR updates NLPModelsKnitro.jl to support the new version of KNITRO.jl (which should be shipped soon)