### PR TITLE
Bug related to FeasibilityFormNLS

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -106,6 +106,7 @@ function knitro!(nlp::AbstractNLPModel, solver::KnitroSolver)
     Δt = real_time = t[2]
   end
 
+  @assert length(x) == nlp.meta.nvar
   return GenericExecutionStats(
     knitro_statuses(nStatus),
     nlp,


### PR DESCRIPTION
This PR exhibits a bug related to NLS models that are converted to FeasibilityFormNLS. A solver is created for the FeasibilityFormNLS model (in `nls.jl`) but inside the `knitro!()` method, information about that FeasibilityFormNLS is lost. As a result, the `stats` and the model are out of sync.

For some reason, no error occurs on line 112 of `api.jl` in the current version
```julia
solution = x
```
but if we use the updated stats  API
```julia
set_solution!(stats, x)
```
an error occurs because `stats.solution` and `x` have different lengths.

If a user passes in an NLS model with general constraints, (s)he should receive in return `stats` that correspond to the original model, not to the intermediate FeasibilityFormNLS.